### PR TITLE
fix: replace deprecated MulticastSocket#joinGroup method

### DIFF
--- a/src/main/java/jp/co/sony/csl/dcoes/apis/common/util/MulticastHandler.java
+++ b/src/main/java/jp/co/sony/csl/dcoes/apis/common/util/MulticastHandler.java
@@ -123,7 +123,11 @@ public class MulticastHandler extends Handler {
 	private synchronized void connect_() throws IOException {
 		sendAddress = InetAddress.getByName(groupAddress);
 		sock = new MulticastSocket(port);
-		sock.joinGroup(sendAddress);
+		NetworkInterface networkInterface = NetworkInterface.getByInetAddress(InetAddress.getLocalHost());
+		if (networkInterface == null) {
+			throw new IOException("No network interface found for: " + InetAddress.getLocalHost());
+		}
+		sock.joinGroup(new InetSocketAddress(sendAddress, port), networkInterface);
 		sock.setTimeToLive(1);
 	}
 


### PR DESCRIPTION
This PR fixes a deprecation warning in apis-common during the Maven build:

`[WARNING] MulticastHandler.java:[126,21] joinGroup(java.net.InetAddress) in java.net.MulticastSocket has been deprecated`