### PR TITLE
Unit tests vertx4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,6 +4,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <vertx.version>4.5.10</vertx.version>
+    <apis.bom.version>3.4.1</apis.bom.version>
   </properties>
 
   <groupId>jp.co.sony.csl.dcoes.apis</groupId>
@@ -17,7 +18,7 @@
       <dependency>
         <groupId>jp.co.sony.csl.dcoes.apis</groupId>
         <artifactId>apis-bom</artifactId>
-        <version>${project.version}</version>
+        <version>${apis.bom.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/test/java/jp/co/sony/csl/dcoes/apis/common/util/vertx/ApisLoggerFormatterTest.java
+++ b/src/test/java/jp/co/sony/csl/dcoes/apis/common/util/vertx/ApisLoggerFormatterTest.java
@@ -3,6 +3,7 @@ package jp.co.sony.csl.dcoes.apis.common.util.vertx;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
+import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -15,6 +16,10 @@ public class ApisLoggerFormatterTest {
 
 	public ApisLoggerFormatterTest() {
 		super();
+	}
+
+	@After public void after() {
+		VertxConfig.config.setJsonObject(null);
 	}
 
 	@Test public void nullProgramId(TestContext context) {

--- a/src/test/java/jp/co/sony/csl/dcoes/apis/common/util/vertx/FileSystemExclusiveLockUtilTest.java
+++ b/src/test/java/jp/co/sony/csl/dcoes/apis/common/util/vertx/FileSystemExclusiveLockUtilTest.java
@@ -22,7 +22,9 @@ public class FileSystemExclusiveLockUtilTest {
 		vertx = Vertx.vertx();
 	}
 	@After public void after(TestContext context) {
-		vertx.close();
+		if (vertx != null) {
+			vertx.close(context.asyncAssertSuccess());
+		}
 	}
 
 	@Test public void once(TestContext context) {

--- a/src/test/java/jp/co/sony/csl/dcoes/apis/common/util/vertx/LocalExclusiveLockTest.java
+++ b/src/test/java/jp/co/sony/csl/dcoes/apis/common/util/vertx/LocalExclusiveLockTest.java
@@ -25,7 +25,9 @@ public class LocalExclusiveLockTest {
 		vertx = Vertx.vertx();
 	}
 	@After public void after(TestContext context) {
-		vertx.close();
+		if (vertx != null) {
+			vertx.close(context.asyncAssertSuccess());
+		}
 	}
 
 	@Test public void releaseTwice(TestContext context) {
@@ -116,10 +118,10 @@ public class LocalExclusiveLockTest {
 			if (res.succeeded()) {
 				LocalExclusiveLock.Lock result = res.result();
 				System.out.println("lock acquired");
-				vertx.setTimer(13000L, v -> {
+				vertx.setTimer(200L, v -> {
 					result.release();
 					System.out.println("lock released");
-					vertx.setTimer(5000L, vv -> {
+					vertx.setTimer(100L, vv -> {
 						System.out.println("done");
 						async.complete();
 					});


### PR DESCRIPTION
Updated the apis-common unit tests so they run correctly with the current stack (Vert.x 4.x, JUnit 4, current apis-common code) and keep the same behavior as before.