### PR TITLE
Added cluster fuzz lite

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,8 @@
+# ClusterFuzzLite build image (OpenSSF Scorecard detects this path).
+# Source is copied in at build time; see https://google.github.io/clusterfuzzlite/build-integration/
+FROM gcr.io/oss-fuzz-base/base-builder-jvm
+RUN apt-get update && apt-get install -y maven git \
+	&& rm -rf /var/lib/apt/lists/*
+COPY . $SRC/apis-common
+WORKDIR $SRC/apis-common
+COPY .clusterfuzzlite/build.sh $SRC/build.sh

--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,5 +1,3 @@
-# ClusterFuzzLite build image (OpenSSF Scorecard detects this path).
-# Source is copied in at build time; see https://google.github.io/clusterfuzzlite/build-integration/
 FROM gcr.io/oss-fuzz-base/base-builder-jvm
 RUN apt-get update && apt-get install -y maven git \
 	&& rm -rf /var/lib/apt/lists/*

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,20 +1,5 @@
 #!/bin/bash -eu
-# Copyright 2026 The APIS Common Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
-# Build apis-common and a Jazzer fuzz target without modifying pom.xml.
-# Mirrors patterns from https://google.github.io/oss-fuzz/getting-started/new-project-guide/jvm-lang/
 
 PROJECT_ROOT="${SRC}/apis-common"
 # Pinned apis-bom (same ref as CI in .github/workflows/ci.yml)

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,69 @@
+#!/bin/bash -eu
+# Copyright 2026 The APIS Common Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build apis-common and a Jazzer fuzz target without modifying pom.xml.
+# Mirrors patterns from https://google.github.io/oss-fuzz/getting-started/new-project-guide/jvm-lang/
+
+PROJECT_ROOT="${SRC}/apis-common"
+# Pinned apis-bom (same ref as CI in .github/workflows/ci.yml)
+APIS_BOM_COMMIT="${APIS_BOM_COMMIT:-266abde1821756ee75bbbdcef1fc746bb66dcc3c}"
+
+rm -rf "${WORK}/apis-bom"
+git clone https://github.com/hyphae/apis-bom.git "${WORK}/apis-bom"
+pushd "${WORK}/apis-bom" >/dev/null
+git checkout "${APIS_BOM_COMMIT}"
+"${MVN:-mvn}" -B -DskipTests install
+popd >/dev/null
+
+pushd "${PROJECT_ROOT}" >/dev/null
+"${MVN:-mvn}" -B -DskipTests package
+cp target/apis-common-*.jar "${OUT}/apis-common.jar"
+mkdir -p "${OUT}/lib"
+"${MVN:-mvn}" -B org.apache.maven.plugins:maven-dependency-plugin:3.6.1:copy-dependencies \
+	-DoutputDirectory="${OUT}/lib" -DincludeScope=runtime
+popd >/dev/null
+
+BUILD_CP="${OUT}/apis-common.jar"
+for j in "${OUT}/lib"/*.jar; do
+	BUILD_CP="${BUILD_CP}:${j}"
+done
+BUILD_CP="${BUILD_CP}:${JAZZER_API_PATH}"
+
+FUZZER_SRC="${PROJECT_ROOT}/fuzz/ApisCommonFuzzer.java"
+javac -cp "${BUILD_CP}" -d "${OUT}" "${FUZZER_SRC}"
+
+RUNTIME_CP=""
+for j in "${OUT}/lib"/*.jar; do
+	RUNTIME_CP="${RUNTIME_CP}\$this_dir/lib/$(basename "${j}"):"
+done
+RUNTIME_CP="${RUNTIME_CP}\$this_dir/apis-common.jar:\$this_dir"
+
+cat >"${OUT}/ApisCommonFuzzer" <<EOF
+#!/bin/bash
+# LLVMFuzzerTestOneInput for fuzzer detection.
+this_dir=\$(dirname "\$0")
+if [[ "\$@" =~ (^| )-runs=[0-9]+($| ) ]]; then
+  mem_settings='-Xmx1900m:-Xss900k'
+else
+  mem_settings='-Xmx2048m:-Xss1024k'
+fi
+LD_LIBRARY_PATH="${JVM_LD_LIBRARY_PATH}:\$this_dir" \\
+\$this_dir/jazzer_driver --agent_path=\$this_dir/jazzer_agent_deploy.jar \\
+--cp=${RUNTIME_CP} \\
+--target_class=ApisCommonFuzzer \\
+--jvm_args="\$mem_settings" \\
+\$@
+EOF
+chmod u+x "${OUT}/ApisCommonFuzzer"

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,2 @@
+# ClusterFuzzLite metadata (see https://google.github.io/clusterfuzzlite/build-integration/)
+language: jvm

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,2 +1,2 @@
-# ClusterFuzzLite metadata (see https://google.github.io/clusterfuzzlite/build-integration/)
+# see https://google.github.io/clusterfuzzlite/build-integration/
 language: jvm

--- a/fuzz/ApisCommonFuzzer.java
+++ b/fuzz/ApisCommonFuzzer.java
@@ -1,0 +1,117 @@
+// Copyright 2026 The APIS Common Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+import jp.co.sony.csl.dcoes.apis.common.util.DateTimeUtil;
+import jp.co.sony.csl.dcoes.apis.common.util.NumberUtil;
+import jp.co.sony.csl.dcoes.apis.common.util.StringUtil;
+import jp.co.sony.csl.dcoes.apis.common.util.vertx.JsonObjectUtil;
+
+/**
+ * Jazzer entry point for OSS-Fuzz / ClusterFuzzLite. Not on the Maven test classpath;
+ * compiled only by {@code .clusterfuzzlite/build.sh} inside the fuzzing image.
+ */
+public class ApisCommonFuzzer {
+	public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+		switch (data.consumeInt(0, 5)) {
+			case 0:
+				fuzzStringAndNumber(data);
+				break;
+			case 1:
+				fuzzDateTime(data);
+				break;
+			case 2:
+				fuzzJsonObject(data);
+				break;
+			case 3:
+				fuzzJsonArray(data);
+				break;
+			case 4:
+				fuzzJsonObjectUtil(data);
+				break;
+			default:
+				fuzzStringAndNumber(data);
+				break;
+		}
+	}
+
+	private static void fuzzStringAndNumber(FuzzedDataProvider data) {
+		String s = data.consumeString(4096);
+		try {
+			StringUtil.nullIfEmpty(s);
+			StringUtil.fixFilePath(s);
+			StringUtil.urlEncode(s);
+			NumberUtil.toInteger(s);
+			Float f = data.consumeBoolean() ? data.consumeRegularFloat() : null;
+			NumberUtil.negativeValue(f);
+		} catch (RuntimeException ignored) {
+		}
+	}
+
+	private static void fuzzDateTime(FuzzedDataProvider data) {
+		String s = data.consumeString(512);
+		try {
+			DateTimeUtil.toLocalDateTime(s);
+			DateTimeUtil.toSystemDefaultZonedDateTime(s);
+		} catch (RuntimeException ignored) {
+		}
+	}
+
+	private static void fuzzJsonObject(FuzzedDataProvider data) {
+		String raw = data.consumeString(8192);
+		try {
+			new JsonObject(raw).encode();
+		} catch (RuntimeException ignored) {
+		}
+	}
+
+	private static void fuzzJsonArray(FuzzedDataProvider data) {
+		String raw = data.consumeString(8192);
+		try {
+			new JsonArray(raw).encode();
+		} catch (RuntimeException ignored) {
+		}
+	}
+
+	private static void fuzzJsonObjectUtil(FuzzedDataProvider data) {
+		String raw = data.consumeString(8192);
+		final JsonObject jo;
+		try {
+			jo = new JsonObject(raw);
+		} catch (RuntimeException e) {
+			return;
+		}
+		int depth = data.consumeInt(1, 8);
+		String[] keys = new String[depth];
+		for (int i = 0; i < depth; i++) {
+			keys[i] = data.consumeString(64);
+		}
+		try {
+			JsonObjectUtil.getValue(jo, keys);
+			JsonObjectUtil.getString(jo, keys);
+			JsonObjectUtil.getFloat(jo, keys);
+			JsonObjectUtil.getInteger(jo, keys);
+			JsonObjectUtil.getLong(jo, keys);
+			JsonObjectUtil.getBoolean(jo, keys);
+			JsonObjectUtil.getLocalDateTime(jo, keys);
+			JsonObjectUtil.getJsonArray(jo, keys);
+			JsonObjectUtil.getJsonObject(jo, keys);
+		} catch (RuntimeException ignored) {
+		}
+	}
+}

--- a/fuzz/ApisCommonFuzzer.java
+++ b/fuzz/ApisCommonFuzzer.java
@@ -1,31 +1,13 @@
-// Copyright 2026 The APIS Common Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
-
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-
 import jp.co.sony.csl.dcoes.apis.common.util.DateTimeUtil;
 import jp.co.sony.csl.dcoes.apis.common.util.NumberUtil;
 import jp.co.sony.csl.dcoes.apis.common.util.StringUtil;
 import jp.co.sony.csl.dcoes.apis.common.util.vertx.JsonObjectUtil;
 
-/**
- * Jazzer entry point for OSS-Fuzz / ClusterFuzzLite. Not on the Maven test classpath;
- * compiled only by {@code .clusterfuzzlite/build.sh} inside the fuzzing image.
- */
+
 public class ApisCommonFuzzer {
 	public static void fuzzerTestOneInput(FuzzedDataProvider data) {
 		switch (data.consumeInt(0, 5)) {

--- a/fuzz/ApisCommonFuzzer.java
+++ b/fuzz/ApisCommonFuzzer.java
@@ -72,9 +72,9 @@ public class ApisCommonFuzzer {
 
 	private static void fuzzJsonObjectUtil(FuzzedDataProvider data) {
 		String raw = data.consumeString(8192);
-		final JsonObject jo;
+		final JsonObject jsonobject;
 		try {
-			jo = new JsonObject(raw);
+			jsonobject = new JsonObject(raw);
 		} catch (RuntimeException e) {
 			return;
 		}
@@ -84,15 +84,15 @@ public class ApisCommonFuzzer {
 			keys[i] = data.consumeString(64);
 		}
 		try {
-			JsonObjectUtil.getValue(jo, keys);
-			JsonObjectUtil.getString(jo, keys);
-			JsonObjectUtil.getFloat(jo, keys);
-			JsonObjectUtil.getInteger(jo, keys);
-			JsonObjectUtil.getLong(jo, keys);
-			JsonObjectUtil.getBoolean(jo, keys);
-			JsonObjectUtil.getLocalDateTime(jo, keys);
-			JsonObjectUtil.getJsonArray(jo, keys);
-			JsonObjectUtil.getJsonObject(jo, keys);
+			JsonObjectUtil.getValue(jsonobject, keys);
+			JsonObjectUtil.getString(jsonobject, keys);
+			JsonObjectUtil.getFloat(jsonobject, keys);
+			JsonObjectUtil.getInteger(jsonobject, keys);
+			JsonObjectUtil.getLong(jsonobject, keys);
+			JsonObjectUtil.getBoolean(jsonobject, keys);
+			JsonObjectUtil.getLocalDateTime(jsonobject, keys);
+			JsonObjectUtil.getJsonArray(jsonobject, keys);
+			JsonObjectUtil.getJsonObject(jsonobject, keys);
 		} catch (RuntimeException ignored) {
 		}
 	}


### PR DESCRIPTION
I've added a small Jazzer harness under fuzz/ plus a ClusterFuzzLite layout in `.clusterfuzzlite/ (Dockerfile, build.sh, and a minimal project.yaml).` 
The harness exercises parsing and utility paths that see untrusted data (JSON, dates, strings) without touching pom.xml, so normal Maven builds stay as they are; the Docker script pins apis-bom the same way CI does, builds the jar, pulls runtime deps, and compiles the fuzzer the way OSS-Fuzz-style JVM projects usually do. The goal is better supply-chain hygiene for OpenSSF Scorecard’s fuzzing signal and a clear path to wire this into OSS-Fuzz or PR fuzzing later, without dragging Jazzer into every developer’s default classpath and every other repo.
Note: 2nd PR for removing extra licensing.