### PR TITLE
Add apiServerApiKey to VertxConfig.java utility 

### DIFF
--- a/src/main/java/jp/co/sony/csl/dcoes/apis/common/util/vertx/VertxConfig.java
+++ b/src/main/java/jp/co/sony/csl/dcoes/apis/common/util/vertx/VertxConfig.java
@@ -85,15 +85,12 @@ public class VertxConfig {
 		return config.getString("security", "pemCertFile");
 	}
 
+	/**
+    * Reads path of api key for validating API-REQUESTS from CONFIG.
+    * @return path of api key.
+    */
+	public static String apiServerApiKey(){
+		return config.getString("apiServer", "apiKey");
+	}
 
-
-/**
-     * Reads path of api key for validating API-REQUESTS from CONFIG.
-     * @return path of api key
-     * CONFIG から API リクエストの検証に使用する API キーのパスを読み込む。
-     * @return API キーのパス
-     */
-public static String apiServerApiKey(){
-	return config.getString("apiServer","apiKey")
-}
 }

--- a/src/main/java/jp/co/sony/csl/dcoes/apis/common/util/vertx/VertxConfig.java
+++ b/src/main/java/jp/co/sony/csl/dcoes/apis/common/util/vertx/VertxConfig.java
@@ -85,4 +85,15 @@ public class VertxConfig {
 		return config.getString("security", "pemCertFile");
 	}
 
+
+
+/**
+     * Reads path of api key for validating API-REQUESTS from CONFIG.
+     * @return path of api key
+     * CONFIG から API リクエストの検証に使用する API キーのパスを読み込む。
+     * @return API キーのパス
+     */
+public static String apiServerApiKey(){
+	return config.getString("apiServer","apiKey")
+}
 }


### PR DESCRIPTION
## Follow up to hyphae/apis-web/pull/13
Reads apiServer.apiKey from CONFIG, used by apis-web's authentication check

@subhramit @axmsoftware 